### PR TITLE
Typo cleanup

### DIFF
--- a/writing_stats.gs
+++ b/writing_stats.gs
@@ -324,7 +324,7 @@ function backupFile(id) {
   /* Create the new file, add it to the almanac folder and remove from the root folder */
   var newFile = orig.makeCopy(orig.getName());
   newFile.addToFolder(folder);
-  newfile.removeFromFolder(DocsList.getRootFolder());
+  newFile.removeFromFolder(DocsList.getRootFolder());
   Logger.log("  -> Backed up original file.");
 
 }


### PR DESCRIPTION
So sorry -- apparently the copying and pasting from local (Github synced) files to the Google Script editor introduced a typo.
