### PR TITLE
avoid throwing #NAME? error when less than 7 days of writing

### DIFF
--- a/writing_stats.gs
+++ b/writing_stats.gs
@@ -250,6 +250,7 @@ function getDailyWordCount() {
   var timeCell = sheet.getRange(WRITING_TIME + range);
   var avgCell = sheet.getRange(WRITING_AVERAGE + range);
   var avgStart = range - 6;
+  avgStart = Math.max(avgStart, 2); // until we have a week of writing data, average the days recorded so far
   
   
   var words = words_fiction + words_nonfiction;


### PR DESCRIPTION
Right now, until there are 7 days of writing for the 7 day average, the `avgStart` var is a negative number, which creates a #NAME? error in sheets. This is confusing and made me think the script wasn't working right.

My solution was to make `avgStart` always at least 2, so that for the first week, the tracker averages the available days (however many).

If this is undesired, I could add a condition to output "Not enough data" instead the `=AVERAGE` formula, so that it avoids calculating, but makes clear to the user that this isn't a bug.

This script is excellent btw. :)